### PR TITLE
[TASK] Replace error-prone shortcut to `typo3/surf` documentation

### DIFF
--- a/webroot/404.html
+++ b/webroot/404.html
@@ -116,7 +116,7 @@
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="typo3cms/extensions/Index.html">Extensions by Extension Key</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://docs.typo3.org/surf/">Surf for Deployment  ➜</a></li>
+<li class="toctree-l1"><a class="reference external" href="https://docs.typo3.org/other/typo3/surf/master/en-us/">Surf for Deployment  ➜</a></li>
 <li class="toctree-l1"><a class="reference internal" href="typo3cms/CheatSheets/Index.html">Cheat Sheets</a></li>
 <li class="toctree-l1"><a class="reference external" href="https://docs.typo3.org/typo3cms/Snippets/">Snippets  ➜</a></li>
 <li class="toctree-l1"><a class="reference internal" href="About.html">About TYPO3 Documentation</a><ul>


### PR DESCRIPTION
The shortcut https://docs.typo3.org/surf is configured manually and thus error-prone as it can link to outdated documentation. Using https://docs.typo3.org/other/typo3/surf/master/en-us/ always links to the latest version of the documentation.

See TYPO3-Documentation/T3DocTeam#159 for further details.